### PR TITLE
Encourage users to install with ember install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ https://github.com/rwjblue/ember-getowner-polyfill
 
 ## Installation
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
+* `ember install ember-transition-helper`
 
 ## Running
 


### PR DESCRIPTION
Ensures that the addon is installed in `devDependencies`.

I must have installed this addon when I didn't know what I was doing and had it in my package.json `dependencies` : (