### PR TITLE
Allow currying

### DIFF
--- a/addon/helpers/transition-to.js
+++ b/addon/helpers/transition-to.js
@@ -5,13 +5,17 @@ export default Helper.extend({
   router: computed(function() {
     return getOwner(this).lookup('router:main');
   }).readOnly(),
+
   compute([routeName, ...params]) {
-    let router = get(this, 'router');
+    const router = get(this, 'router');
     assert('[ember-transition-helper] Unable to lookup router', router);
+
     return function(...invocationArgs) {
-      let args = params.concat(invocationArgs);
-      let transitionArgs = params.length ? [routeName, ...params] : [routeName];
-      router.transitionTo.apply(router, transitionArgs);
+      const args = params.concat(invocationArgs);
+      const transitionArgs = args.length ? [routeName, ...args] : [routeName];
+
+      router.transitionTo(...transitionArgs);
+
       return args;
     };
   }


### PR DESCRIPTION
Part of the power of the Data Down, Actions Up paradigm is the ability to pass actions down through layers of components, with each layer having the possibility to add parameters to the action invocation should they wish to.

This change allows the `transition-to` helper to act in the same way, making usage like this possible:

```
{{!-- posts.hbs --}}
{{posts-list posts=model onPostSelected=(action (transition-to "posts.post"))}}
```
```
{{!-- posts-list.hbs --}}
{{#each posts as |post|}}
  {{posts-list/item post=post onSelected=(action onPostSelected post)}}
{{/each}}
```