### PR TITLE
Set version to 1.0.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-transition-helper",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
@peec Thank you for accepting my PR!
It looks like you are [considering the latest code as v1.0.0](https://github.com/peec/ember-transition-helper/tree/1.0.0) but haven't [published to `npm` yet](https://www.npmjs.com/package/ember-transition-helper). Before you do, would you please also set the appropriate version string in `package.json`? (This PR sets to 1.0.0, in case that is what you want. Feel free to close it unmerged and use something else.)